### PR TITLE
fix: dashboard and markets pages stats colors to white for readability

### DIFF
--- a/src/components/incentives/IncentivesCard.tsx
+++ b/src/components/incentives/IncentivesCard.tsx
@@ -41,7 +41,7 @@ export const IncentivesCard = ({
           variant={variant}
           symbolsVariant={symbolsVariant}
           color={color}
-          symbolsColor={color}
+          symbolsColor={color || 'text.white'}
         />
       ) : (
         <NoData variant={variant} color={color || 'text.secondary'} />

--- a/src/modules/dashboard/lists/ListValueColumn.tsx
+++ b/src/modules/dashboard/lists/ListValueColumn.tsx
@@ -28,6 +28,7 @@ const Content = ({
           variant="secondary14"
           sx={{ mb: !withTooltip && !!subValue ? '2px' : 0 }}
           color={disabled ? 'text.disabled' : 'text.main'}
+          symbolsColor='text.white'
           data-cy={`nativeAmount`}
         />
         {capsComponent}

--- a/src/modules/dashboard/lists/ListValueRow.tsx
+++ b/src/modules/dashboard/lists/ListValueRow.tsx
@@ -27,6 +27,7 @@ export const ListValueRow = ({
             value={value}
             variant="secondary14"
             color={disabled ? 'text.disabled' : 'text.primary'}
+            symbolsColor='text.white'
           />
           {capsComponent}
         </Box>

--- a/src/modules/markets/MarketAssetsListItem.tsx
+++ b/src/modules/markets/MarketAssetsListItem.tsx
@@ -51,7 +51,7 @@ export const MarketAssetsListItem = ({ ...reserve }: ComputedReserveData) => {
       </ListColumn>
 
       <ListColumn>
-        <FormattedNumber compact value={reserve.totalLiquidity} variant="main16" />
+        <FormattedNumber compact value={reserve.totalLiquidity} variant="main16" symbolsColor='text.white' />
         <ReserveSubheader value={reserve.totalLiquidityUSD} />
       </ListColumn>
 
@@ -71,7 +71,7 @@ export const MarketAssetsListItem = ({ ...reserve }: ComputedReserveData) => {
       <ListColumn>
         {reserve.borrowingEnabled || Number(reserve.totalDebt) > 0 ? (
           <>
-            <FormattedNumber compact value={reserve.totalDebt} variant="main16" />{' '}
+            <FormattedNumber compact value={reserve.totalDebt} variant="main16" symbolsColor='text.white' />{' '}
             <ReserveSubheader value={reserve.totalDebtUSD} />
           </>
         ) : (

--- a/src/modules/markets/MarketAssetsListMobileItem.tsx
+++ b/src/modules/markets/MarketAssetsListMobileItem.tsx
@@ -33,7 +33,7 @@ export const MarketAssetsListMobileItem = ({ ...reserve }: ComputedReserveData) 
             textAlign: 'center',
           }}
         >
-          <FormattedNumber compact value={reserve.totalLiquidity} variant="secondary14" />
+          <FormattedNumber compact value={reserve.totalLiquidity} variant="secondary14" symbolsColor='text.white' />
           <ReserveSubheader value={reserve.totalLiquidityUSD} rightAlign={true} />
         </Box>
       </Row>
@@ -66,7 +66,7 @@ export const MarketAssetsListMobileItem = ({ ...reserve }: ComputedReserveData) 
         >
           {Number(reserve.totalDebt) > 0 ? (
             <>
-              <FormattedNumber compact value={reserve.totalDebt} variant="secondary14" />
+              <FormattedNumber compact value={reserve.totalDebt} variant="secondary14" symbolsColor='text.white' />
               <ReserveSubheader value={reserve.totalDebtUSD} rightAlign={true} />
             </>
           ) : (


### PR DESCRIPTION
fix: dashboard and markets pages stats colors to white for readability